### PR TITLE
Mods to check the resx returns for empty string in addition to nulls.

### DIFF
--- a/Components/NBrightBuyUtils.cs
+++ b/Components/NBrightBuyUtils.cs
@@ -760,7 +760,7 @@ namespace Nevoweb.DNN.NBrightBuy.Components
                     {
                         var resxpath = StoreSettings.NBrightBuyPath() + "/App_LocalResources/Notification.ascx.resx";
                         emailsubject = DnnUtils.GetLocalizedString(emailsubjectresxkey, resxpath, lang);
-                        if (emailsubject == null) emailsubject = emailsubjectresxkey;
+                        if (string.IsNullOrWhiteSpace(emailsubject)) emailsubject = emailsubjectresxkey;
                     }
 
                     // we can't use StoreSettings.Current.Settings(), becuase of external calls from providers to this function, so load in the settings directly  


### PR DESCRIPTION
I believe the resx values are returning empty strings so the null check won't work to allow for overriding the value with a string if a resx key is not found.