### PR TITLE
Defensive check to preserve the order status in the GUIDKey 

### DIFF
--- a/Components/PurchaseData.cs
+++ b/Components/PurchaseData.cs
@@ -71,7 +71,7 @@ namespace Nevoweb.DNN.NBrightBuy.Components
             {
                 if (UserId != UserController.Instance.GetCurrentUserInfo().UserID && EditMode == "") UserId = UserController.Instance.GetCurrentUserInfo().UserID;
                 PurchaseInfo.UserId = UserId;
-                PurchaseInfo.GUIDKey = UserId.ToString("");
+                if (PurchaseTypeCode=="CART") PurchaseInfo.GUIDKey = UserId.ToString("");
                 if (EditMode == "" && !string.IsNullOrEmpty(UserController.Instance.GetCurrentUserInfo().Profile.PreferredLocale))
                 {
                     ClientLang = UserController.Instance.GetCurrentUserInfo().Profile.PreferredLocale;


### PR DESCRIPTION
I believe this prevents issues once the Type Code has been converted to ORDER