### PR TITLE
Ensure Checkout Order Summary is visible

### DIFF
--- a/Themes/Default/js/checkout.js
+++ b/Themes/Default/js/checkout.js
@@ -257,6 +257,9 @@
                 }
 
                 if (e.cmd == 'cart_shippingprovidertemplate') {
+                    $([document.documentElement, document.body]).animate({
+                        scrollTop: 0
+                    }, 1000);
                 }
 
                 if (e.cmd == 'cart_recalculatesummary2') {


### PR DESCRIPTION
Next button clicks from the Billing and Shipping address checkout leave the Summary content partially off screen.  Js added to ensure the user views the order summary without having to scroll.