### PR TITLE
Add new property default bool should be proper cased

### DIFF
--- a/Components/Categories/CategoryFunctions.cs
+++ b/Components/Categories/CategoryFunctions.cs
@@ -172,7 +172,7 @@ namespace Nevoweb.DNN.NBrightBuy.Components.Category
             var selgroup = ajaxInfo.GetXmlProperty("genxml/hidden/selectedgroup");
             if (selgroup == "") selgroup = "cat";
             categoryData.GroupType = selgroup;
-            categoryData.DataRecord.SetXmlProperty("genxml/checkbox/chkishidden", "true");
+            categoryData.DataRecord.SetXmlProperty("genxml/checkbox/chkishidden", "True");
             categoryData.DataRecord.ParentItemId = ajaxInfo.GetXmlPropertyInt("genxml/hidden/selectedcatid");
             categoryData.DataRecord.SetXmlProperty("genxml/dropdownlist/ddlparentcatid", categoryData.DataRecord.ParentItemId.ToString());
             categoryData.Save();


### PR DESCRIPTION
New properties are being entered with a non standard bool value that is lowercase.  It won't reflect properly in the details view unless you re-save the property.  Small chance this may be related to issue #57