### PR TITLE
Fix delete plugin example

### DIFF
--- a/Plugins/readme.txt
+++ b/Plugins/readme.txt
@@ -26,7 +26,7 @@ Remove system level
 To remove system level pugins you can add an xml to the plugins folder with a delete flag and ctrl ref.
 
 <genxml>
-	<deleted>True</deleted>
+	<delete>True</delete>
 	<textbox>
 		<ctrl>nameofctrl</ctrl>
 	</textbox>


### PR DESCRIPTION
This readme is slightly wrong.  This will help users trying to delete a plugin.