### PR TITLE
Add input type search support

### DIFF
--- a/Themes/ClassicAjax/Default/Search.cshtml
+++ b/Themes/ClassicAjax/Default/Search.cshtml
@@ -25,7 +25,7 @@
     <div class="h4-headline">@ResourceKey("General.findaproduct")</div>
     <div class="nbssearchfield">
         <div class="nbssearchinput">
-            @NBrightTextBox(info, "genxml/textbox/searchtext", "maxlength='150' placeholder='" + @ResourceKey("General.Search") + "' class='NormalTextBox'")
+            @NBrightTextBox(info, "genxml/textbox/searchtext", "type='search' maxlength='150' placeholder='" + @ResourceKey("General.Search") + "' class='NormalTextBox'")
             <input id="uilang" type="hidden" value="@Utils.GetCurrentCulture()">
             <input id="modulekey" type="hidden" update="save" value="@Model.GetSetting("targetmodulekey")">
             <input id="navigationmode" update="save" type="hidden" value="f">

--- a/Themes/config/js/jquery.genxmlajax.js
+++ b/Themes/config/js/jquery.genxmlajax.js
@@ -197,7 +197,7 @@
 				var typecode = 'cb';
 				if (parentflag) typecode = 'cbl';
 					values += '<f t="' + typecode + '" ' + strUpdate + ' id="' + shortID + '" for="' + $('label[for=' + strID + ']').text() + '" val="' + element.attr("value") + '">' + element.is(':checked') + '</f>';
-            } else if (element.attr("type") == 'text' || element.attr("type") == 'date' || element.attr("type") == 'email' || element.attr("type") == 'url' || element.attr("type") == 'number') {
+            } else if (element.attr("type") == 'text' || element.attr("type") == 'date' || element.attr("type") == 'email' || element.attr("type") == 'url' || element.attr("type") == 'number' || element.attr("type") == 'search') {
                 if (element.attr("datatype") === undefined) {
                     values += '<f t="txt" ' + strUpdate + ' id="' + shortID + '"><![CDATA[' + element.val() + ']]></f>';
                 } else {


### PR DESCRIPTION
Minor js change to allow passing data using the input type search.  It'll enable most browsers to clear the data from the input box without any additional code.