### PR TITLE
Properties by products

### DIFF
--- a/Components/DataProvider.cs
+++ b/Components/DataProvider.cs
@@ -84,7 +84,8 @@ namespace Nevoweb.DNN.NBrightBuy.Components
         public abstract IDataReader GetPropertyListByProduct(int PortalId, int ModuleId, string TypeCode, string SQLSearchFilter, string SQLOrderBy, int ReturnLimit, int PageNumber, int PageSize, int RecordCount, string TypeCodeLang, string lang);
 		public abstract IDataReader GetPropertyListByProductIds(string itemIds);
 		public abstract int GetListCount(int PortalId, int ModuleId, string TypeCode, string SQLSearchFilter, string TypeCodeLang, string lang);
-        public abstract IDataReader Get(int ItemID, string TypeCodeLang, string lang);
+		public abstract IDataReader GetListCountWithProperties(int PortalId, int ModuleId, string TypeCode, string SQLSearchFilter, string TypeCodeLang, string lang);
+		public abstract IDataReader Get(int ItemID, string TypeCodeLang, string lang);
         public abstract int Update(int ItemId, int PortalId, int ModuleId, String TypeCode, String XMLData, String GUIDKey, DateTime ModifiedDate, String TextData, int XrefItemId, int ParentItemId, int UserId, string lang);
 		public abstract void Delete(int ItemID);
 		public abstract void CleanData();

--- a/Components/DataProvider.cs
+++ b/Components/DataProvider.cs
@@ -21,7 +21,8 @@ namespace Nevoweb.DNN.NBrightBuy.Components
         public abstract NBrightInfo GetData(int itemId);
         public abstract NBrightInfo GetDataLang(int parentItemId, string lang);
         public abstract List<PropertyByProductInfo> GetPropertyListByProduct(int PortalId, int ModuleId, string TypeCode, string SQLSearchFilter, string SQLOrderBy, int ReturnLimit, int PageNumber, int PageSize, int RecordCount, string TypeCodeLang, string lang);
-    }
+		public abstract List<PropertyByProductInfo> GetPropertyListByProductIds(string itemIds);
+	}
     /// -----------------------------------------------------------------------------
     /// <summary>
     /// An abstract class for the data access layer
@@ -81,7 +82,8 @@ namespace Nevoweb.DNN.NBrightBuy.Components
 
         public abstract IDataReader GetList(int PortalId, int ModuleId, string TypeCode, string SQLSearchFilter, string SQLOrderBy, int ReturnLimit, int PageNumber, int PageSize, int RecordCount, string TypeCodeLang, string lang);
         public abstract IDataReader GetPropertyListByProduct(int PortalId, int ModuleId, string TypeCode, string SQLSearchFilter, string SQLOrderBy, int ReturnLimit, int PageNumber, int PageSize, int RecordCount, string TypeCodeLang, string lang);
-        public abstract int GetListCount(int PortalId, int ModuleId, string TypeCode, string SQLSearchFilter, string TypeCodeLang, string lang);
+		public abstract IDataReader GetPropertyListByProductIds(string itemIds);
+		public abstract int GetListCount(int PortalId, int ModuleId, string TypeCode, string SQLSearchFilter, string TypeCodeLang, string lang);
         public abstract IDataReader Get(int ItemID, string TypeCodeLang, string lang);
         public abstract int Update(int ItemId, int PortalId, int ModuleId, String TypeCode, String XMLData, String GUIDKey, DateTime ModifiedDate, String TextData, int XrefItemId, int ParentItemId, int UserId, string lang);
 		public abstract void Delete(int ItemID);

--- a/Components/ItemLists/ListCount.cs
+++ b/Components/ItemLists/ListCount.cs
@@ -1,0 +1,8 @@
+﻿namespace Nevoweb.DNN.NBrightBuy.Components.ItemLists
+{
+    public class ListCount
+    {
+        public int Count { get; set; }
+        public string Properties { get; set; }
+    }
+}

--- a/Components/NBrightBuyController.cs
+++ b/Components/NBrightBuyController.cs
@@ -164,6 +164,19 @@ namespace Nevoweb.DNN.NBrightBuy.Components
             }
         }
 
+        public override List<PropertyByProductInfo> GetPropertyListByProductIds(string itemIds)
+        {
+            try
+            {
+                return CBO.FillCollection<PropertyByProductInfo>(DataProvider.Instance().GetPropertyListByProductIds(itemIds));
+            }
+            catch (Exception e)
+            {
+                Logging.LogException(e);
+                throw;
+            }
+        }
+
         /// <summary>
         /// override for Database Function
         /// </summary>
@@ -986,11 +999,12 @@ namespace Nevoweb.DNN.NBrightBuy.Components
 
 		}
 
+
         #endregion
 
 
-		#endregion
+        #endregion
 
-	}
+    }
 
 }

--- a/Components/Product/ProductFunctions.cs
+++ b/Components/Product/ProductFunctions.cs
@@ -2139,7 +2139,8 @@ namespace Nevoweb.DNN.NBrightBuy.Components.Products
 
                     strFilter += " and (NB3.Visible = 1) "; // get only visible products
 
-                    var recordCount = ModCtrl.GetDataListCount(ps.PortalId, moduleid, EntityTypeCode, strFilter, EntityTypeCodeLang, Utils.GetCurrentCulture(), DebugMode);
+                    var lc = ModCtrl.GetDataListCountWithProperties(ps.PortalId, moduleid, EntityTypeCode, strFilter, EntityTypeCodeLang, Utils.GetCurrentCulture(), DebugMode);
+                    var recordCount = lc.Count;
 
                     if (returnlimit > 0 && returnlimit < recordCount) recordCount = returnlimit;
 
@@ -2153,24 +2154,23 @@ namespace Nevoweb.DNN.NBrightBuy.Components.Products
                         retval = "";
 
                         var l = ModCtrl.GetDataList(ps.PortalId, moduleid, EntityTypeCode, EntityTypeCodeLang, Utils.GetCurrentCulture(), strFilter, navigationdata.OrderBy, DebugMode, "", returnlimit, pageNumber, pageSize, recordCount);
-
-                        var itemIds = (from i in l
-                                       select i.ItemID).ToList();
-
-                        var propertyList = itemIds.Count > 0 ? ModCtrl.GetPropertyListByProductIds(string.Join(",", itemIds.Select(n => n.ToString()).ToArray())) : new List<PropertyByProductInfo>();
-
+                        
                         navigationdata.ClearPropertyFilters();
-                        foreach (var p in propertyList)
+
+                        var itemIds = lc.Properties.Split(','); 
+                        foreach (var i in itemIds)
                         {
-                            navigationdata.AddPropertyFilter(p.PropId);
+                            if (int.TryParse(i, out int itemId)) {
+                                navigationdata.AddPropertyFilter(itemId);
+                            }
                         }
+
                         navigationdata.RecordCount = recordCount.ToString("");
                         navigationdata.Save();
 
                         if (!ModSettings.Settings().ContainsKey("recordcount")) ModSettings.Settings().Add("recordcount", "");
                         ModSettings.Settings()["recordcount"] = recordCount.ToString();
                         retval = NBrightBuyUtils.RazorTemplRenderList(_templD, moduleid, razorcachekey, l, TemplateRelPath, ModSettings.ThemeFolder, Utils.GetCurrentCulture(), ModSettings.Settings());
-
                     }
 
                     if (navigationdata.SingleSearchMode) navigationdata.ResetSearch();

--- a/Components/Product/ProductFunctions.cs
+++ b/Components/Product/ProductFunctions.cs
@@ -2151,11 +2151,14 @@ namespace Nevoweb.DNN.NBrightBuy.Components.Products
                     if (retval == null || DebugMode)
                     {
                         retval = "";
-                        //if (defcatid != "0")  // no category will cause error.
-                        //{
+
                         var l = ModCtrl.GetDataList(ps.PortalId, moduleid, EntityTypeCode, EntityTypeCodeLang, Utils.GetCurrentCulture(), strFilter, navigationdata.OrderBy, DebugMode, "", returnlimit, pageNumber, pageSize, recordCount);
 
-                        var propertyList = ModCtrl.GetPropertyListByProduct(ps.PortalId, moduleid, EntityTypeCode, EntityTypeCodeLang, Utils.GetCurrentCulture(), strFilter, navigationdata.OrderBy, DebugMode, "", returnlimit, pageNumber, pageSize, recordCount);
+                        var itemIds = (from i in l
+                                       select i.ItemID).ToList();
+
+                        var propertyList = itemIds.Count > 0 ? ModCtrl.GetPropertyListByProductIds(string.Join(",", itemIds.Select(n => n.ToString()).ToArray())) : new List<PropertyByProductInfo>();
+
                         navigationdata.ClearPropertyFilters();
                         foreach (var p in propertyList)
                         {
@@ -2165,9 +2168,9 @@ namespace Nevoweb.DNN.NBrightBuy.Components.Products
                         navigationdata.Save();
 
                         if (!ModSettings.Settings().ContainsKey("recordcount")) ModSettings.Settings().Add("recordcount", "");
-                            ModSettings.Settings()["recordcount"] = recordCount.ToString();
-                            retval = NBrightBuyUtils.RazorTemplRenderList(_templD, moduleid, razorcachekey, l, TemplateRelPath, ModSettings.ThemeFolder, Utils.GetCurrentCulture(), ModSettings.Settings());
-                        //}
+                        ModSettings.Settings()["recordcount"] = recordCount.ToString();
+                        retval = NBrightBuyUtils.RazorTemplRenderList(_templD, moduleid, razorcachekey, l, TemplateRelPath, ModSettings.ThemeFolder, Utils.GetCurrentCulture(), ModSettings.Settings());
+
                     }
 
                     if (navigationdata.SingleSearchMode) navigationdata.ResetSearch();

--- a/Components/SqlDataProvider/SqlDataProvider.cs
+++ b/Components/SqlDataProvider/SqlDataProvider.cs
@@ -132,6 +132,10 @@ namespace Nevoweb.DNN.NBrightBuy.Components.SqlDataProvider
         {
             return SqlHelper.ExecuteReader(ConnectionString, DatabaseOwner + ObjectQualifier + "NBrightBuy_GetPropertyByProductList", portalId, moduleId, typeCode, sqlSearchFilter, sqlOrderBy, returnLimit, typeCodeLang, lang);
         }
+        public override IDataReader GetPropertyListByProductIds(string itemIds)
+        {
+            return SqlHelper.ExecuteReader(ConnectionString, DatabaseOwner + ObjectQualifier + "NBrightBuy_GetPropertyByProductIds", itemIds);
+        }
 
         public override int GetListCount(int portalId, int moduleId, string typeCode, string sqlSearchFilter = "", string typeCodeLang = "", string lang = "")
         {

--- a/Components/SqlDataProvider/SqlDataProvider.cs
+++ b/Components/SqlDataProvider/SqlDataProvider.cs
@@ -134,7 +134,7 @@ namespace Nevoweb.DNN.NBrightBuy.Components.SqlDataProvider
         }
         public override IDataReader GetPropertyListByProductIds(string itemIds)
         {
-            return SqlHelper.ExecuteReader(ConnectionString, DatabaseOwner + ObjectQualifier + "NBrightBuy_GetPropertyByProductIds", itemIds);
+            return SqlHelper.ExecuteReader(ConnectionString, DatabaseOwner + ObjectQualifier + "NBrightBuy_GetPropertyListByProductIds", itemIds);
         }
 
         public override int GetListCount(int portalId, int moduleId, string typeCode, string sqlSearchFilter = "", string typeCodeLang = "", string lang = "")

--- a/Components/SqlDataProvider/SqlDataProvider.cs
+++ b/Components/SqlDataProvider/SqlDataProvider.cs
@@ -142,6 +142,11 @@ namespace Nevoweb.DNN.NBrightBuy.Components.SqlDataProvider
             return Convert.ToInt32(SqlHelper.ExecuteScalar(ConnectionString, DatabaseOwner + ObjectQualifier + "NBrightBuy_GetListCount", portalId, moduleId, typeCode, sqlSearchFilter, typeCodeLang, lang));
         }
 
+        public override IDataReader GetListCountWithProperties(int portalId, int moduleId, string typeCode, string sqlSearchFilter = "", string typeCodeLang = "", string lang = "")
+        {
+            return SqlHelper.ExecuteReader(ConnectionString, DatabaseOwner + ObjectQualifier + "NBrightBuy_GetListCountWithProperties", portalId, moduleId, typeCode, sqlSearchFilter, typeCodeLang, lang);
+        }
+
         public override IDataReader Get(int itemId, string typeCodeLang = "", string lang = "")
         {
             return SqlHelper.ExecuteReader(ConnectionString, DatabaseOwner + ObjectQualifier + "NBrightBuy_Get", itemId, typeCodeLang, lang);

--- a/Installation/04.01.02.SqlDataProvider
+++ b/Installation/04.01.02.SqlDataProvider
@@ -1,0 +1,30 @@
+/****** Object:  StoredProcedure {databaseOwner}[{objectQualifier}NBrightBuy_GetPropertyByProductIds]    Script Date: 27/11/2019 10:08:08 ******/
+SET ANSI_NULLS ON
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+if exists (select * from dbo.sysobjects where id = object_id(N'{databaseOwner}[{objectQualifier}NBrightBuy_GetPropertyByProductIds]') and OBJECTPROPERTY(id, N'IsProcedure') = 1)
+drop procedure {databaseOwner}[{objectQualifier}NBrightBuy_GetPropertyByProductIds]
+GO
+
+CREATE PROCEDURE {databaseOwner}[{objectQualifier}NBrightBuy_GetPropertyByProductIds]
+@ItemIds nvarchar(max)
+
+AS
+begin
+
+DECLARE @STMT nvarchar(max) -- SQL to execute
+
+Set @STMT = 'select distinct XRefItemId '
+Set @STMT = @STMT + ' from {databaseOwner}[{objectQualifier}NBrightBuy] as NB1 '
+Set @STMT = @STMT + ' where Typecode=''CATXREF'' ' 
+Set @STMT = @STMT + ' and ParentItemId in (' + @ItemIds + ')'
+
+EXEC sp_executeSQL @STMT
+
+end
+GO
+
+

--- a/Installation/04.01.02.SqlDataProvider
+++ b/Installation/04.01.02.SqlDataProvider
@@ -1,10 +1,3 @@
-/****** Object:  StoredProcedure {databaseOwner}[{objectQualifier}NBrightBuy_GetPropertyByProductIds]    Script Date: 27/11/2019 10:08:08 ******/
-SET ANSI_NULLS ON
-GO
-
-SET QUOTED_IDENTIFIER ON
-GO
-
 if exists (select * from dbo.sysobjects where id = object_id(N'{databaseOwner}[{objectQualifier}NBrightBuy_GetPropertyByProductIds]') and OBJECTPROPERTY(id, N'IsProcedure') = 1)
 drop procedure {databaseOwner}[{objectQualifier}NBrightBuy_GetPropertyByProductIds]
 GO
@@ -28,3 +21,82 @@ end
 GO
 
 
+if exists (select * from dbo.sysobjects where id = object_id(N'{databaseOwner}[{objectQualifier}NBrightBuy_GetListCountWithProperties]') and OBJECTPROPERTY(id, N'IsProcedure') = 1)
+drop procedure {databaseOwner}[{objectQualifier}NBrightBuy_GetListCountWithProperties]
+GO
+
+CREATE  PROCEDURE {databaseOwner}[{objectQualifier}NBrightBuy_GetListCountWithProperties]
+@PortalId int, 
+@ModuleId int,
+@TypeCode nvarchar(50),
+@Filter nvarchar(max),
+@TypeCodeLang nvarchar(50) = '',
+@Lang nvarchar(10) = ''
+
+AS
+begin
+
+-- This SPROC return the Get List COUNT with LANGAUGE and NO PAGING
+
+	SET NOCOUNT ON
+	  DECLARE
+		@STMT nvarchar(max),         -- SQL to execute
+		@recct int                  -- total # of records (for paging interface)
+		,@parentIds nvarchar(max)	-- csv string of property ids
+		,@properties nvarchar(max)	-- csv string of property ids
+
+	IF (@PortalId >= 0) BEGIN
+
+		IF (@ModuleId >= 0) BEGIN
+			SET @Filter = ' and (PortalId = '''  + Convert(nvarchar(10),@PortalId) + ''' or PortalId = ''-1'') and (ModuleId = ''' + Convert(nvarchar(10),@ModuleId) + ''' or ModuleId = ''-1'') ' + @Filter
+		END ELSE BEGIN
+			SET @Filter = ' and (PortalId = '''  + Convert(nvarchar(10),@PortalId) + '''  or PortalId = ''-1'') ' + @Filter
+		END 
+
+	END 
+
+	SET @Filter = REPLACE(@Filter,'[XMLData]','ISNULL(NB2.[XMLData],NB1.[XMLData])')
+
+	-- Return records without paging.
+	set @STMT = 'SELECT  NB1.[ItemId] FROM {databaseOwner}[{objectQualifier}NBrightBuy] as NB1 ' 	
+	set @STMT = @STMT + ' left join  {databaseOwner}[{objectQualifier}NBrightBuyIdx] as NB3 on NB3.ItemId = NB1.ItemId and NB3.[Lang] = ''' + @Lang + ''''	
+	set @STMT = @STMT + '  left join {databaseOwner}[{objectQualifier}NBrightBuyLang] as NB2 on NB2.ParentItemId = NB1.ItemId and NB2.lang = ''' + @Lang + '''' 
+	
+	IF (RIGHT(@TypeCode,1) = '%')
+	BEGIN
+		set @STMT = @STMT + ' WHERE NB1.TypeCode Like ''' + @TypeCode + ''' ' + @Filter 
+	END ELSE
+	BEGIN
+		IF (@TypeCode = '')
+		BEGIN
+			set @STMT = @STMT + ' WHERE NB1.TypeCode != '''' ' + @Filter 
+		END ELSE
+		BEGIN
+			set @STMT = @STMT + ' WHERE NB1.TypeCode = ''' + @TypeCode + ''' ' + @Filter  
+		END
+	END
+               
+	CREATE TABLE #TempProducts  
+	(            
+		[ItemId] [int]
+	)
+	INSERT INTO #TempProducts(
+		[ItemId]
+	)
+	EXEC sp_executeSQL @STMT
+
+	Set @recct = (SELECT Count(ItemId) from #TempProducts)
+
+	Set @properties = (select substring((select distinct ',' + Cast(XRefItemId as varchar(10))  
+		from dbo.[NBrightBuy] as NB1 
+		where ParentItemId in (select distinct ItemId FROM #TempProducts) 
+		AND Typecode='CATXREF' FOR XML PATH('')),2,2000000) AS CSV
+	)
+
+	DROP TABLE #TempProducts
+
+	SELECT @recct as Count, @properties as Properties
+
+end
+
+GO

--- a/Installation/04.01.02.SqlDataProvider
+++ b/Installation/04.01.02.SqlDataProvider
@@ -1,8 +1,8 @@
-if exists (select * from dbo.sysobjects where id = object_id(N'{databaseOwner}[{objectQualifier}NBrightBuy_GetPropertyByProductIds]') and OBJECTPROPERTY(id, N'IsProcedure') = 1)
-drop procedure {databaseOwner}[{objectQualifier}NBrightBuy_GetPropertyByProductIds]
+if exists (select * from dbo.sysobjects where id = object_id(N'{databaseOwner}[{objectQualifier}NBrightBuy_GetPropertyListByProductIds]') and OBJECTPROPERTY(id, N'IsProcedure') = 1)
+drop procedure {databaseOwner}[{objectQualifier}NBrightBuy_GetPropertyListByProductIds]
 GO
 
-CREATE PROCEDURE {databaseOwner}[{objectQualifier}NBrightBuy_GetPropertyByProductIds]
+CREATE PROCEDURE {databaseOwner}[{objectQualifier}NBrightBuy_GetPropertyListByProductIds]
 @ItemIds nvarchar(max)
 
 AS

--- a/Installation/Uninstall.SqlDataProvider
+++ b/Installation/Uninstall.SqlDataProvider
@@ -110,8 +110,10 @@ if exists (select * from dbo.sysobjects where id = object_id(N'{databaseOwner}[{
 DROP PROCEDURE {databaseOwner}[{objectQualifier}NBrightBuy_GetDNNUserProductClient]
 GO
 
+if exists (select * from dbo.sysobjects where id = object_id(N'{databaseOwner}[{objectQualifier}NBrightBuy_GetPropertyByProductIds]') and OBJECTPROPERTY(id, N'IsProcedure') = 1)
+drop procedure {databaseOwner}[{objectQualifier}NBrightBuy_GetPropertyByProductIds]
+GO
 
-
-
-
-
+if exists (select * from dbo.sysobjects where id = object_id(N'{databaseOwner}[{objectQualifier}NBrightBuy_GetListCountWithProperties]') and OBJECTPROPERTY(id, N'IsProcedure') = 1)
+drop procedure {databaseOwner}[{objectQualifier}NBrightBuy_GetListCountWithProperties]
+GO

--- a/Installation/Uninstall.SqlDataProvider
+++ b/Installation/Uninstall.SqlDataProvider
@@ -110,8 +110,8 @@ if exists (select * from dbo.sysobjects where id = object_id(N'{databaseOwner}[{
 DROP PROCEDURE {databaseOwner}[{objectQualifier}NBrightBuy_GetDNNUserProductClient]
 GO
 
-if exists (select * from dbo.sysobjects where id = object_id(N'{databaseOwner}[{objectQualifier}NBrightBuy_GetPropertyByProductIds]') and OBJECTPROPERTY(id, N'IsProcedure') = 1)
-drop procedure {databaseOwner}[{objectQualifier}NBrightBuy_GetPropertyByProductIds]
+if exists (select * from dbo.sysobjects where id = object_id(N'{databaseOwner}[{objectQualifier}NBrightBuy_GetPropertyListByProductIds]') and OBJECTPROPERTY(id, N'IsProcedure') = 1)
+drop procedure {databaseOwner}[{objectQualifier}NBrightBuy_GetPropertyListByProductIds]
 GO
 
 if exists (select * from dbo.sysobjects where id = object_id(N'{databaseOwner}[{objectQualifier}NBrightBuy_GetListCountWithProperties]') and OBJECTPROPERTY(id, N'IsProcedure') = 1)

--- a/NBrightBuy.csproj
+++ b/NBrightBuy.csproj
@@ -214,6 +214,7 @@
     <Compile Include="CartRazorViewSettings.ascx.designer.cs">
       <DependentUpon>CartRazorViewSettings.ascx.cs</DependentUpon>
     </Compile>
+    <Compile Include="Components\ItemLists\ListCount.cs" />
     <Compile Include="ProductListAjaxFilter.ascx.cs">
       <DependentUpon>ProductListAjaxFilter.ascx</DependentUpon>
       <SubType>ASPXCodeBehind</SubType>

--- a/NBrightBuy.csproj
+++ b/NBrightBuy.csproj
@@ -601,6 +601,7 @@
     <None Include="Installation\04.00.11.SqlDataProvider" />
     <None Include="Installation\04.00.04.SqlDataProvider" />
     <None Include="Installation\04.00.02.SqlDataProvider" />
+    <None Include="Installation\04.01.02.SqlDataProvider" />
     <None Include="Installation\Uninstall.SqlDataProvider" />
     <None Include="packages.config" />
     <None Include="README.md" />

--- a/OpenStore.dnn
+++ b/OpenStore.dnn
@@ -108,6 +108,10 @@
               <name>04.01.01.SqlDataProvider</name>
               <version>04.01.01</version>
             </script>
+            <script type="Install">
+              <name>04.01.02.SqlDataProvider</name>
+              <version>04.01.02</version>
+            </script>
             <script type="UnInstall">
               <name>Uninstall.SqlDataProvider</name>
               <version>04.00.00</version>


### PR DESCRIPTION
This will return the properties used in the filtering in the same sproc as the list count.  Initial approach was using the list view paged data and wasn't accurate.  The SQL and data provider code for that is still in place because it works however it's not being used by this PR.  Overall this reduces db activity & performs better especially if there is more complex filtering.  One could make the list count SQL dryer with more refactoring of the original sproc but it isn't critical.  Take a look at where the ListCount class is placed and make sure it's in it's proper place(thought about using  NBrightInfo).  It required adding a Using to it in NBrightBuyController so that also may be worth reviewing... I think it's alright but we can change it if you have a better approach.