### PR TITLE
Make the cart user specific.

### DIFF
--- a/Components/Cart/CartFunctions.cs
+++ b/Components/Cart/CartFunctions.cs
@@ -126,13 +126,14 @@ namespace Nevoweb.DNN.NBrightBuy.Components.Cart
             {
                 if (lang == "") lang = Utils.GetCurrentCulture();
                 var currentcart = new CartData(PortalSettings.Current.PortalId);
-                if (currentcart.UserId != UserController.Instance.GetCurrentUserInfo().UserID && currentcart.EditMode == "")
+                var userId = UserController.Instance.GetCurrentUserInfo().UserID;
+                if (currentcart.UserId != userId && currentcart.EditMode == "")
                 {
                     //do save to update userid, so addrees checkout can get addresses. (Even if no user "-1")
                     currentcart.Save();
                 }
 
-                razorTempl = NBrightBuyUtils.RazorTemplRender(carttemplate, 0, "", currentcart, controlpath, theme, lang, StoreSettings.Current.Settings());
+                razorTempl = NBrightBuyUtils.RazorTemplRender(carttemplate, 0, userId.ToString(), currentcart, controlpath, theme, lang, StoreSettings.Current.Settings());
             }
             return razorTempl;
         }


### PR DESCRIPTION
This makes the cart unique by user to prevent a user from logging on to the same PC resulting in seeing the last user's cart data.  It may also fix #36 though technically the cache key is already portal specific so the case scenario described you'll want to test again.