### PR TITLE
Make dashboard orders link to details

### DIFF
--- a/Themes/config/default/dashboard.html
+++ b/Themes/config/default/dashboard.html
@@ -39,6 +39,12 @@ function xGraphOrderTotals(){
 
 	$( document ).ready(function() {
 		xGraphOrderTotals();
+
+        //make order numbers link to order details
+        $("a.ordernumber").click(function (event) {
+            var eid = $(this).data("eid");
+            location.href = "/Admin/NBS-Back-Office/ctrl/orders/eid/" + eid.toString().substring(6);
+        });
 	});
 
 </script>

--- a/Themes/config/default/dashboard.html
+++ b/Themes/config/default/dashboard.html
@@ -40,10 +40,10 @@ function xGraphOrderTotals(){
 	$( document ).ready(function() {
 		xGraphOrderTotals();
 
-        //make order numbers link to order details
-        $("a.ordernumber").click(function (event) {
-            var eid = $(this).data("eid");
-            location.href = "/Admin/NBS-Back-Office/ctrl/orders/eid/" + eid.toString().substring(6);
+		//make order numbers link to order details
+		$("a.ordernumber").click(function (event) {
+			var eid = $(this).data("eid");
+			location.href = "../orders/eid/" + eid.toString().substring(6);
         });
 	});
 

--- a/Themes/config/default/dashordersbody.html
+++ b/Themes/config/default/dashordersbody.html
@@ -2,7 +2,7 @@
 
 <tr>
     <td>[<tag type="orderstatusdisplay" />]</td>
-    <td>[<tag type='valueof' xpath='genxml/ordernumber' />]</td>
+    <td><a class="ordernumber" data-eid="[<tag type='valueof' xpath='genxml/ordernumber' />]" href="#"> [<tag type='valueof' xpath='genxml/ordernumber' />]</a></td>
     <td>[<tag type='valueof' xpath='genxml/createddate' datatype='date' format='dd MMM yyyy H:mm' />]</td>
 	[<tag type="if" function="settings" key="cataloguemode" testvalue="True" display="{OFF}" />]<!-- Catalogue mode -->
     <td class="text-right">[<tag type="currencyof" xpath="genxml/appliedtotal" />]</td>


### PR DESCRIPTION
Links to order details from the dashboard to help make managing the orders easier.  It would be great to get the order detail page's return button to return back to the dashboard when a user arrives on an order detail via the dashboard.  Otherwise they end up going back to the main order list if they click the return button.  I don't think there is a token for the return tab id we can pass as the rtntab query param in the order details url? 