### PR TITLE
Fixes item list delete paramCmd

### DIFF
--- a/Components/ItemLists/ItemListsFunctions.cs
+++ b/Components/ItemLists/ItemListsFunctions.cs
@@ -54,7 +54,7 @@ namespace Nevoweb.DNN.NBrightBuy.Components.ItemLists
                         strOut = cw.products;
                     }
                     break;
-                case "itemlist_deletelist":
+                case "itemlist_delete":
                     cw.DeleteList(itemlistname);
                     strOut = "deleted";
                     break;


### PR DESCRIPTION
The paramCmd generated by the button click to remove all lists isn't matching the server side switch case.  This fixes it on the server side and leaves product.js that creates the request as is.