### PR TITLE
Refactor shipping tax rates

### DIFF
--- a/Providers/TaxProvider/App_LocalResources/Tax.ascx.fr-FR.resx
+++ b/Providers/TaxProvider/App_LocalResources/Tax.ascx.fr-FR.resx
@@ -126,6 +126,9 @@
   <data name="enabletaxnumber.Text" xml:space="preserve">
     <value>Autoriser l'exonération des taxes selon un numéro de taxes (EU)</value>
   </data>
+  <data name="shippingtaxrate.Text" xml:space="preserve">
+    <value>Taux de taxe d'expédition (%)</value>
+  </data>
   <data name="taxdefault.Text" xml:space="preserve">
     <value>Taxe par défaut (%)</value>
   </data>

--- a/Providers/TaxProvider/App_LocalResources/Tax.ascx.nl.resx
+++ b/Providers/TaxProvider/App_LocalResources/Tax.ascx.nl.resx
@@ -126,6 +126,9 @@
   <data name="enabletaxnumber.Text" xml:space="preserve">
     <value>Gebruik van (EU) belastingnummer inschakelen voor belastingvrijstelling</value>
   </data>
+  <data name="shippingtaxarate.Text" xml:space="preserve">
+    <value>Belastingtarief voor verzending (%)</value>
+  </data>
   <data name="taxdefault.Text" xml:space="preserve">
     <value>Standaardbelasting (%)</value>
   </data>

--- a/Providers/TaxProvider/App_LocalResources/Tax.ascx.resx
+++ b/Providers/TaxProvider/App_LocalResources/Tax.ascx.resx
@@ -135,6 +135,9 @@
   <data name="taxrate.Text" xml:space="preserve">
     <value>Tax Rate (%)</value>
   </data>
+    <data name="shippingtaxrate.Text" xml:space="preserve">
+    <value>Shipping Tax Rate (%)</value>
+  </data>
   <data name="taxtype.data" xml:space="preserve">
     <value>Tax Included in Unit Price;Tax NOT Included in Unit Price;No Tax;Tax Included in Unit Price (zero tax total)</value>
   </data>

--- a/Providers/TaxProvider/TaxProvider.cs
+++ b/Providers/TaxProvider/TaxProvider.cs
@@ -56,10 +56,7 @@ namespace Nevoweb.DNN.NBrightBuy.Providers
                 if (enableShippingTax && nodList.Count > 0)
                 {
 
-                    // Set tax rate vars to use with shipping based on the 1st product in cart
-                    // NOTE: Consider adding shippingcost & dealershippingcost in the product xml
-                    //       to allow for product specific shipping tax rates
-                    
+                    // Set tax rate & dealer status based on values from the 1st product in cart
                     var productInfo = new NBrightInfo { XMLData = nodList[0].OuterXml };
                     var taxrate = GetTaxRate(productInfo, rateDic);
                     var isDealer = productInfo.GetXmlPropertyBool("genxml/isdealer");

--- a/Providers/TaxProvider/TaxProvider.cs
+++ b/Providers/TaxProvider/TaxProvider.cs
@@ -25,6 +25,7 @@ namespace Nevoweb.DNN.NBrightBuy.Providers
         public override NBrightInfo Calculate(NBrightInfo cartInfo)
         {
             var enableShippingTax = _info.GetXmlPropertyBool("genxml/checkbox/enableshippingtax");
+            var shippingTaxRate = _info.GetXmlPropertyDouble("genxml/textbox/shippingtaxrate");
 
             // return taxtype, 1 = included in cost, 2 = not included in cost, 3 = no tax, 4 = tax included in cost, but calculate to zero.
             cartInfo.SetXmlPropertyDouble("genxml/taxtype", _taxType);
@@ -53,15 +54,14 @@ namespace Nevoweb.DNN.NBrightBuy.Providers
                     taxtotal += CalculateItemTax(nbi, rateDic);
                 }
 
-                if (enableShippingTax && nodList.Count > 0)
+                if (enableShippingTax && shippingTaxRate > 0)
                 {
 
-                    // Set tax rate & dealer status based on values from the 1st product in cart
+                    // Set dealer status based on values from the 1st product in cart
                     var productInfo = new NBrightInfo { XMLData = nodList[0].OuterXml };
-                    var taxrate = GetTaxRate(productInfo, rateDic);
                     var isDealer = productInfo.GetXmlPropertyBool("genxml/isdealer");
 
-                    taxtotal += CalculateShippingTax(cartInfo, taxrate, isDealer);
+                    taxtotal += CalculateShippingTax(cartInfo, shippingTaxRate, isDealer);
                 }
 
                 cartInfo.SetXmlPropertyDouble("genxml/taxcost", taxtotal);

--- a/Providers/TaxProvider/Themes/config/default/settings.html
+++ b/Providers/TaxProvider/Themes/config/default/settings.html
@@ -63,6 +63,13 @@
                     </div>
 
                     <div class="form-group">
+                        <label class="col-sm-3 control-label">[<tag type="valueof" resourcekey="Tax.shippingtaxrate" />]</label>
+                        <div class="col-sm-1">
+                            [<tag id="shippingtaxrate" cssclass="form-control" type="textbox" Text="" />]
+                        </div>
+                    </div>
+
+                    <div class="form-group">
                         <label class="col-sm-3 control-label">[<tag type="valueof" resourcekey="Tax.taxexemptregions" />]</label>
                         <div class="col-sm-4">
                             [<tag id="taxexemptregions" cssclass="form-control" type="textbox" Text="" />]


### PR DESCRIPTION
Mods to support the shipping tax rate coming from Tax Provider.   The dealer status to determine which shipping cost to apply is relying on a cart item which is not ideal.  I don't think I've overlooked a better location to use for determining this but we can adjust for it if there is.