### PR TITLE
Added an option to calculate shipping on cart total value in place of subtotal (original price)

### DIFF
--- a/App_LocalResources/General.ascx.resx
+++ b/App_LocalResources/General.ascx.resx
@@ -1231,6 +1231,6 @@
     <value>Dealer Only</value>
   </data>
   <data name="Carttotal.Text" xml:space="preserve">
-    <value>Cart total</value>
+    <value>Subtotal</value>
   </data>
 </root>

--- a/App_LocalResources/General.ascx.resx
+++ b/App_LocalResources/General.ascx.resx
@@ -1230,4 +1230,7 @@
   <data name="DealerOnly.Text" xml:space="preserve">
     <value>Dealer Only</value>
   </data>
+  <data name="Carttotal.Text" xml:space="preserve">
+    <value>Cart total</value>
+  </data>
 </root>

--- a/Components/Cart/CartData.cs
+++ b/Components/Cart/CartData.cs
@@ -327,6 +327,10 @@ namespace Nevoweb.DNN.NBrightBuy.Components
             var carttotal = (subtotalcost) - promototaldiscount;
             PurchaseInfo.SetXmlPropertyDouble("genxml/carttotalvalue", carttotal);
 
+            //Data to later be use on checkoutTotals.cshtml
+            String freeshiplimitontotal = PurchaseInfo.GetXmlProperty("genxml/extrainfo/genxml/checkbox/freeshiplimitontotal");
+            PurchaseInfo.SetXmlProperty("genxml/extrainfo/genxml/checkbox/freeshiplimitontotal", freeshiplimitontotal);
+
             if (total < 0) total = 0;
             PurchaseInfo.SetXmlPropertyDouble("genxml/total", total);
             PurchaseInfo.SetXmlPropertyDouble("genxml/appliedtotal", total);

--- a/Components/Cart/CartData.cs
+++ b/Components/Cart/CartData.cs
@@ -263,8 +263,7 @@ namespace Nevoweb.DNN.NBrightBuy.Components
             PurchaseInfo.SetXmlPropertyDouble("genxml/subtotalcost", subtotalcost);
             PurchaseInfo.SetXmlPropertyDouble("genxml/subtotal", subtotalcost);
             PurchaseInfo.SetXmlPropertyDouble("genxml/appliedsubtotal", (subtotalcost + totalsalediscount));
-
-
+ 
             // calc any voucher amounts
             var discountcode = PurchaseInfo.GetXmlProperty("genxml/extrainfo/genxml/textbox/promocode");
             Double voucherDiscount = 0;
@@ -282,7 +281,9 @@ namespace Nevoweb.DNN.NBrightBuy.Components
 
             PurchaseInfo.SetXmlPropertyDouble("genxml/totaldiscount", totaldiscount);
             PurchaseInfo.SetXmlPropertyDouble("genxml/totalsalediscount", totalsalediscount);
-
+            
+            //Subtotal minus discount. 
+            PurchaseInfo.SetXmlPropertyDouble("genxml/carttotalvalue", (subtotalcost - totaldiscount));
 
             //add shipping
             Double shippingcost = 0;
@@ -318,8 +319,14 @@ namespace Nevoweb.DNN.NBrightBuy.Components
                 appliedtax = PurchaseInfo.GetXmlPropertyDouble("genxml/appliedtax");
             }
 
+
             //cart full total
             var total = (subtotalcost + shippingcost + appliedtax) - promototaldiscount;
+
+            /* Total value as seen in the cart*/
+            var carttotal = (subtotalcost) - promototaldiscount;
+            PurchaseInfo.SetXmlPropertyDouble("genxml/carttotalvalue", carttotal);
+
             if (total < 0) total = 0;
             PurchaseInfo.SetXmlPropertyDouble("genxml/total", total);
             PurchaseInfo.SetXmlPropertyDouble("genxml/appliedtotal", total);

--- a/Providers/ShippingProvider/App_LocalResources/Shipping.ascx.resx
+++ b/Providers/ShippingProvider/App_LocalResources/Shipping.ascx.resx
@@ -150,4 +150,7 @@
   <data name="FreeShippingLimit.Text" xml:space="preserve">
     <value>Free Shipping Limit</value>
   </data>
+  <data name="OnCartTotal.Text" xml:space="preserve">
+    <value>Calculate on cart total</value>
+  </data>
 </root>

--- a/Providers/ShippingProvider/ShippingData.cs
+++ b/Providers/ShippingProvider/ShippingData.cs
@@ -95,6 +95,14 @@ namespace Nevoweb.DNN.NBrightBuy.Providers
             }
         }
 
+        public String FreeshiplimitOnTotaalx
+        {
+            get
+            {
+                return Info.GetXmlProperty("genxml/checkbox/freeshiplimitontotal");
+            }
+        }
+
         #endregion
 
         #region "base methods"

--- a/Providers/ShippingProvider/ShippingProvider.cs
+++ b/Providers/ShippingProvider/ShippingProvider.cs
@@ -20,11 +20,17 @@ namespace Nevoweb.DNN.NBrightBuy.Providers
                 rangeValue = cartInfo.GetXmlPropertyDouble("genxml/totalweight"); 
             else
                 rangeValue = cartInfo.GetXmlPropertyDouble("genxml/appliedsubtotal");
+
+            if (shipData.FreeshiplimitOnTotaalx == "True") rangeValue = cartInfo.GetXmlPropertyDouble("genxml/carttotalvalue");
+
             var countrycode = "";
             var regioncode = "";
             var regionkey = "";
             var postCode = "";
             var total = cartInfo.GetXmlPropertyDouble("genxml/appliedsubtotal");
+
+            if (shipData.FreeshiplimitOnTotaalx == "True") total = cartInfo.GetXmlPropertyDouble("genxml/carttotalvalue");
+
             switch (shipoption)
             {
                 case "1":

--- a/Providers/ShippingProvider/Themes/config/default/shippingheader.html
+++ b/Providers/ShippingProvider/Themes/config/default/shippingheader.html
@@ -57,13 +57,17 @@
         <div class="box-content">
             <div class="form-horizontal dnnForm">
                 <div class="form-group">
-                    <label class="col-sm-2 control-label">[<tag type="valueof" resourcekey="Shipping.FreeShippingLimit"/>]</label>
+                    <label class="col-sm-2 control-label">[<tag type="valueof" resourcekey="Shipping.FreeShippingLimit" />]</label>
                     <div class="col-sm-1">
-                        [<tag id="freeshiplimit" cssclass="form-control" type="textbox" maxlength="150" Text="0"/>]
+                        [<tag id="freeshiplimit" cssclass="form-control" type="textbox" maxlength="150" Text="0" />]
                     </div>
-                    <label class="col-sm-2 control-label">[<tag type="valueof" resourcekey="Shipping.CountryCodesCSV"/>]</label>
+                    <label class="col-sm-2 control-label">[<tag type="valueof" resourcekey="Shipping.CountryCodesCSV" />]</label>
                     <div class="col-sm-3">
-                        [<tag id="freeshipcountrycodes" cssclass="form-control" type="textbox" Text=""/>]
+                        [<tag id="freeshipcountrycodes" cssclass="form-control" type="textbox" Text="" />]
+                    </div>
+                    <label class="col-sm-2 control-label">[<tag type="valueof" resourcekey="Shipping.OnCartTotal" />]</label>
+                    <div class="col-sm-2">
+                        [<tag id="freeshiplimitontotal" type="checkbox" datavalue="1" repeatcolumns="1" />]
                     </div>
                 </div>
             </div>

--- a/Themes/Default/Default/CheckoutTotals.cshtml
+++ b/Themes/Default/Default/CheckoutTotals.cshtml
@@ -18,9 +18,11 @@
     // assign Model, so we can resolve var in VS
     var cart = (CartData)Model.List.First();
     var info = cart.PurchaseInfo;
-}
-
+}                   
+             @if(info.GetXmlProperty("genxml/extrainfo/genxml/checkbox/freeshiplimitontotal") == "True"){ <li class="large"><div>@ResourceKey("General.Carttotal")</div>@NBrightBuyUtils.FormatToStoreCurrency(info.GetXmlPropertyDouble("genxml/carttotalvalue"))</li>}
+             else{
                 <li class="large"><div>@ResourceKey("General.Subtotal")</div>@NBrightBuyUtils.FormatToStoreCurrency(info.GetXmlPropertyDouble("genxml/appliedsubtotal"))</li>
+                }
                 <li class="large"><div>@ResourceKey("General.Discount")</div>@NBrightBuyUtils.FormatToStoreCurrency(info.GetXmlPropertyDouble("genxml/applieddiscount"))</li>
 <li class="large">
     <div>@ResourceKey("General.Shipping")</div>@NBrightBuyUtils.FormatToStoreCurrency(info.GetXmlPropertyDouble("genxml/appliedshipping"))</li>


### PR DESCRIPTION
Added an option so shop owners can choose to calculating shipping on subtotal (original price) or calculating shipping on cart total value which already applies discount.

The shipping provider has a new checkbox for this use case and when activated the subtotal (original price) will be replace with subtotal (cart total value).