### PR TITLE
Enable users to remove list

### DIFF
--- a/Themes/Default/Default/ItemList.cshtml
+++ b/Themes/Default/Default/ItemList.cshtml
@@ -42,14 +42,14 @@
                 }
             }
             Model.List = newlist;
-
+        <div id="list-@(listkey)">
             <h3>@cw.listnames[listkey]</h3>
 
             <div>
             @RenderTemplate("\\DesktopModules\\NBright\\NBrightBuy\\Themes\\Default\\Default\\ItemListProducts.cshtml", Model)
             <div class="slp-footer"><a class="wishlistremoveall primarybutton" listkey="@(listkey)"><i class="fa fa-trash"></i> @ResourceKey("ProductView.wishlistclearall")</a></div>
             </div>
-
+        </div>
         }
     }
 

--- a/Themes/Default/js/product.js
+++ b/Themes/Default/js/product.js
@@ -217,11 +217,10 @@ function AjaxView_GetList_nbxproductgetCompleted(e) {
     });
 
     $('.wishlistremoveall').click(function (e) {
-        $('#shoplistname').val(e.target.attributes.listkey.value);
+        var listkey = $(e.target).attr("listkey");
+        $('#shoplistname').val(listkey);
         nbxproductget('itemlist_delete', '#productajaxview'); //apply serverside
-        //remove list title and products
-        $(e.target).parent().parent().prev().remove();
-        $(e.target).parent().parent().remove();
+        $("#list-" + listkey).remove();
     });
 
     $('.shoplistselect').unbind("change");

--- a/Themes/Default/js/product.js
+++ b/Themes/Default/js/product.js
@@ -216,9 +216,12 @@ function AjaxView_GetList_nbxproductgetCompleted(e) {
         nbxproductget('itemlist_remove', '#productajaxview'); //apply serverside
     });
 
-    $('.wishlistremoveall').unbind("click");
-    $('.wishlistremoveall').click(function () {
+    $('.wishlistremoveall').click(function (e) {
+        $('#shoplistname').val(e.target.attributes.listkey.value);
         nbxproductget('itemlist_delete', '#productajaxview'); //apply serverside
+        //remove list title and products
+        $(e.target).parent().parent().prev().remove();
+        $(e.target).parent().parent().remove();
     });
 
     $('.shoplistselect').unbind("change");


### PR DESCRIPTION
 I think this may be an option for addressing the remove list issue.  The main culprit was the missing hidden input. I altered the jquery that hides the html product lines since it was affecting all lists.  This limits the client side html elements being removed to the proper list.  