### PR TITLE
Add caching support for CartData ValidateCart promo providers.

### DIFF
--- a/Components/Cart/CartData.cs
+++ b/Components/Cart/CartData.cs
@@ -222,7 +222,13 @@ namespace Nevoweb.DNN.NBrightBuy.Components
             // Calculate first, so if we add items the price is calculated
             if (PromoInterface.Instance() != null)
             {
-                var promol = PromoInterface.ProviderList;
+                var cacheKey = "promol" + PortalId;
+                var promol = (Dictionary<string, PromoInterface>)Utils.GetCache(cacheKey);
+                if (promol == null)
+                {
+                    promol = PromoInterface.ProviderList;
+                    Utils.SetCache(cacheKey, promol);
+                }
                 foreach (var p in promol)
                 {
                     PurchaseInfo = PromoInterface.Instance(p.Key).CalculatePromotion(PortalId, PurchaseInfo);


### PR DESCRIPTION
If there are pathways that need to clear this cache key we should identify them but I think in most situations changes to the promo providers would/should involve a server cache clear anyhow.  The ValidateCart function gets called multiple times so leaning on cache should help a little bit here.