### PR TITLE
improved related products

### DIFF
--- a/Themes/Bootstrap4/Default/ProductDisplayDetail.cshtml
+++ b/Themes/Bootstrap4/Default/ProductDisplayDetail.cshtml
@@ -306,12 +306,15 @@
         </div>
         <!-- End Details -->
         <!-- Related Items -->
-        @if (@product.GetRelatedProducts().Count >= 1)
+        @{
+            var relatedProducts = product.GetRelatedProducts();
+        }
+        @if (relatedProducts.Count >= 1)
         {
             <h3>@ResourceKey("ProductView.recommend")</h3>
             <div id="relatedwrapper" class="row productlist">
             <!-- Related products -->
-            @foreach (var rp in product.GetRelatedProducts())
+            @foreach (var rp in relatedProducts)
             {
                 var rproduct = new ProductData(rp.ItemID, rp.Lang);
                 <div class="col-12 col-md-6 col-lg-4 col-xxl-3 mb-4">

--- a/Themes/ClassicAjax/Default/ProductDisplayDetail.cshtml
+++ b/Themes/ClassicAjax/Default/ProductDisplayDetail.cshtml
@@ -269,12 +269,15 @@ else
         </div>
         <!-- End Details -->
         <!-- Related Items -->
-        @if (@product.GetRelatedProducts().Count >= 1)
+        @{
+            var relatedProducts = product.GetRelatedProducts();
+        }
+        @if (relatedProducts.Count >= 1)
         {
             <div class="h2-headline">@ResourceKey("ProductView.recommend")</div>
             <div id="relatedwrapper" class="productlist">
                 <!-- Related products -->
-                @foreach (var rp in product.GetRelatedProducts())
+                @foreach (var rp in relatedProducts)
                 {
                     var rproduct = new ProductData(rp.ItemID, rp.Lang);
                     <div class="product">


### PR DESCRIPTION
This PR adds an overloads for GetRelatedProducts to use in razor scripts.

In stead of 
`var relatedProducts = product.GetRelatedProducts();`
which only gives you the products that have been registered as related, you can now also give an integer as a parameter:
`var relatedProducts = product.GetRelatedProducts(6);`
which will add products from the same categories your product is in, up the number you passed in.