### PR TITLE
Enhance portal id usage

### DIFF
--- a/Components/GrpCatController.cs
+++ b/Components/GrpCatController.cs
@@ -338,10 +338,15 @@ namespace Nevoweb.DNN.NBrightBuy.Components
                 notcat = "cat";
             }
 
-            var joinItems = (from d1 in GrpCategoryList
+            var joinItems = new List<GroupCategoryData>();
+            if (GrpCategoryList != null)
+            {
+                joinItems = (from d1 in GrpCategoryList
                              join d2 in catxrefList on d1.categoryid equals d2.XrefItemId
                              where (d1.grouptyperef == groupref || groupref == "") && d1.grouptyperef != notcat
                              select d1).OrderBy(d1 => d1.grouptyperef).ThenBy(d1 => d1.breadcrumb).ToList<GroupCategoryData>();
+
+            }
             return joinItems;
         }
 

--- a/Components/NBrightBuyController.cs
+++ b/Components/NBrightBuyController.cs
@@ -915,28 +915,33 @@ namespace Nevoweb.DNN.NBrightBuy.Components
             return dlang;
         }
 
-        /// <summary>
-            /// Get current portal StoreSettings
-            /// </summary>
-            /// <returns></returns>
-        public static StoreSettings GetCurrentPortalData()
-	    {
+        public static StoreSettings GetPortalData(int portalId)
+        {
             StoreSettings objPortalSettings = null;
             if (HttpContext.Current != null)
             {
                 // build StoreSettings and place in httpcontext
-                if (HttpContext.Current.Items["NBBStoreSettings" + PortalSettings.Current.PortalId.ToString("")] == null)
+                if (HttpContext.Current.Items["NBBStoreSettings" + portalId.ToString()] == null)
                 {
-                    HttpContext.Current.Items.Add("NBBStoreSettings" + PortalSettings.Current.PortalId.ToString(""),GetStaticStoreSettings(PortalSettings.Current.PortalId));
+                    HttpContext.Current.Items.Add("NBBStoreSettings" + portalId.ToString(), GetStaticStoreSettings(portalId));
                 }
-                objPortalSettings = (StoreSettings)HttpContext.Current.Items["NBBStoreSettings" + PortalSettings.Current.PortalId.ToString("")];
+                objPortalSettings = (StoreSettings)HttpContext.Current.Items["NBBStoreSettings" + portalId.ToString()];
             }
             else
             {
                 // capture all to ensure we pass something.
-                objPortalSettings = GetStaticStoreSettings(PortalSettings.Current.PortalId);
+                objPortalSettings = GetStaticStoreSettings(portalId);
             }
             return objPortalSettings;
+        }
+
+        /// <summary>
+        /// Get current portal StoreSettings
+        /// </summary>
+        /// <returns></returns>
+        public static StoreSettings GetCurrentPortalData()
+	    {
+            return GetPortalData(PortalSettings.Current.PortalId);
 	    }
 
         /// <summary>

--- a/Components/Product/ProductData.cs
+++ b/Components/Product/ProductData.cs
@@ -444,14 +444,15 @@ namespace Nevoweb.DNN.NBrightBuy.Components
         /// <summary>
         /// Select categories linked to product, by groupref
         /// </summary>
+        /// <param name="portalId"></param>
         /// <param name="groupref">groupref for select, "" = all, "cat"= Category only, "!cat" = all non-category, "{groupref}"=this group only</param>
         /// <param name="cascade">get all cascade records to get all parent categories</param>
         /// <returns></returns>
-        public List<GroupCategoryData> GetCategories(String groupref = "", Boolean cascade = false)
+        public List<GroupCategoryData> GetCategories(int portalId, String groupref = "", Boolean cascade = false)
         {
             if (Info == null) return new List<GroupCategoryData>(); // stop throwing an error no product exists,
 
-            var objGrpCtrl = new GrpCatController(_lang);
+            var objGrpCtrl = new GrpCatController(_lang, portalId);
             var catl = objGrpCtrl.GetProductCategories(Info.ItemID, groupref, cascade);
             if (Utils.IsNumeric(DataRecord.GetXmlProperty("genxml/defaultcatid")) && catl.Count > 0)
             {
@@ -466,6 +467,19 @@ namespace Nevoweb.DNN.NBrightBuy.Components
                 if (groupCategoryDatas.Any()) groupCategoryDatas.First().isdefault = true;
             }
             return catl;
+        }
+
+
+        /// <summary>
+        /// Select categories linked to product, by groupref
+        /// </summary>
+        /// <param name="groupref">groupref for select, "" = all, "cat"= Category only, "!cat" = all non-category, "{groupref}"=this group only</param>
+        /// <param name="cascade">get all cascade records to get all parent categories</param>
+        /// <returns></returns>
+        public List<GroupCategoryData> GetCategories(String groupref = "", Boolean cascade = false)
+        {
+            var portalId = PortalSettings.Current.PortalId;
+            return GetCategories(portalId, groupref, cascade);
         }
 
         /// <summary>
@@ -689,6 +703,7 @@ namespace Nevoweb.DNN.NBrightBuy.Components
                 DataRecord = objCtrl.Get(productid);
                 DataLangRecord = objCtrl.Get(plangid);
             }
+
         }
 
         private void UpdateDisplayCalcPrices()
@@ -1744,6 +1759,7 @@ namespace Nevoweb.DNN.NBrightBuy.Components
                 }
                 lp += 1;
             }
+
             //Fix document paths
             lp = 1;
             foreach (var d in Docs)
@@ -1794,7 +1810,7 @@ namespace Nevoweb.DNN.NBrightBuy.Components
             }
 
             // remove duplicate category xrefs.
-            var catlist = GetCategories();
+            var catlist = GetCategories(_portalId);
             foreach (var c in catlist)
             {
                 var l = objCtrl.GetList(_portalId, -1, "CATXREF", " and NB1.ParentItemId = " + Info.ItemID.ToString("") + " and NB1.XrefItemId = " + c.categoryid.ToString(""));
@@ -1835,6 +1851,7 @@ namespace Nevoweb.DNN.NBrightBuy.Components
                 objCtrl.Delete(c.ItemID);
                 errorcount += 1;
             }
+
             // remove catcascade record that have no catxref record for the product.
             var caslist = new List<int>();
             var catcascadelist = objCtrl.GetList(_portalId, -1, "CATCASCADE", " and nb1.ParentItemId = '" + Info.ItemID + "' ");
@@ -1843,10 +1860,10 @@ namespace Nevoweb.DNN.NBrightBuy.Components
                 caslist.Add(n.XrefItemId);
             }
 
-            var catlist2 = GetCategories();
+            var catlist2 = GetCategories(_portalId);
             if (catlist2.Any())
             {
-                var objGrpCtrl = new GrpCatController(_lang, true);
+                var objGrpCtrl = new GrpCatController(_lang, _portalId, true);
                 foreach (var cat in catlist2)
                 {
                     var parentcats = objGrpCtrl.GetCategory(cat.categoryid);
@@ -1876,10 +1893,9 @@ namespace Nevoweb.DNN.NBrightBuy.Components
                 }
             }
 
-
-
             // update shared product if flagged
-            if (StoreSettings.Current.GetBool("shareproducts") && DataRecord.PortalId >= 0)
+            StoreSettings storeSettings  = (System.Web.HttpContext.Current != null) ? StoreSettings.Current : new StoreSettings(_portalId);
+            if (storeSettings.GetBool("shareproducts") && DataRecord.PortalId >= 0)
             {
                 upd = true;
                 DataRecord.PortalId = -1;
@@ -1889,7 +1905,7 @@ namespace Nevoweb.DNN.NBrightBuy.Components
                 }
             }
 
-            // check if we have empty model name ()
+            // check if we have empty model name
             var modellp = 1;
             foreach (var m in Models)
             {
@@ -1975,13 +1991,11 @@ namespace Nevoweb.DNN.NBrightBuy.Components
                 }
             }
 
-
             return errorcount;
         }
 
         public int Copy()
         {
-
             var objCtrl = new NBrightBuyController();
 
             //Copy Base record 
@@ -2082,7 +2096,6 @@ namespace Nevoweb.DNN.NBrightBuy.Components
                             dlang.SetXmlProperty("genxml/edt/description", DataLangRecord.GetXmlPropertyRaw("genxml/edt/description"));
                         }
                     }
-
 
                     // models
                     var nodList1 = DataLangRecord.XMLDoc.SelectNodes("genxml/models/genxml");
@@ -2214,14 +2227,10 @@ namespace Nevoweb.DNN.NBrightBuy.Components
             }
         }
 
-
         public void OutputDebugFile(String filePathName)
         {
             Info.XMLDoc.Save(filePathName);
         }
-
-
-
 
         #endregion
 
@@ -2311,7 +2320,6 @@ namespace Nevoweb.DNN.NBrightBuy.Components
 
         private int AddNew()
         {
-
             var nbi = new NBrightInfo(true);
             if (StoreSettings.Current.Get("shareproducts") == "True") // option in storesetting to share products created here across all portals.
                 _portalId = -1;
@@ -2467,7 +2475,6 @@ namespace Nevoweb.DNN.NBrightBuy.Components
             if (price == -1) price = 0;
             return price;
         }
-
 
         private bool CheckClientFileUpload()
         {

--- a/Components/Product/ProductUtils.cs
+++ b/Components/Product/ProductUtils.cs
@@ -455,6 +455,29 @@ namespace Nevoweb.DNN.NBrightBuy.Components
             return mcList;
         }
 
+        /// <summary>
+        /// Get ProductData class with cacheing
+        /// </summary>
+        /// <param name="productId"></param>
+        /// <param name="portalId"></param>
+        /// <param name="lang"></param>
+        /// <param name="hydrateLists"></param>
+        /// <param name="typeCode">Typecode of record default "PRD"</param>
+        /// <param name="typeLangCode">Langauge Typecode of record default "PRDLANG"</param>
+        /// <returns></returns>
+        public static ProductData GetProductData(int productId, int portalId, String lang, Boolean hydrateLists = true, String typeCode = "PRD")
+        {
+            ProductData prdData;
+            var cacheKey = "NBSProductData*" + productId.ToString("") + "*" + lang;
+            prdData = (ProductData)Utils.GetCache(cacheKey);
+            if ((prdData == null) || (productId == -1))
+            {
+                prdData = new ProductData(productId, portalId, lang, hydrateLists, typeCode);
+                Utils.SetCache(cacheKey, prdData);
+            }
+            return prdData;
+        }
+
 
         /// <summary>
         /// Get ProductData class with cacheing
@@ -467,15 +490,11 @@ namespace Nevoweb.DNN.NBrightBuy.Components
         /// <returns></returns>
         public static ProductData GetProductData(int productId, String lang, Boolean hydrateLists = true, String typeCode = "PRD")
         {
-            ProductData prdData;
-            var cacheKey = "NBSProductData*" + productId.ToString("") + "*" + lang;
-            prdData = (ProductData)Utils.GetCache(cacheKey);
-            if ((prdData == null) || (productId == -1))
+            if (Utils.IsNumeric(productId))
             {
-                prdData = new ProductData(productId, lang, hydrateLists, typeCode);
-                Utils.SetCache(cacheKey, prdData);
+                return GetProductData(Convert.ToInt32(productId), PortalSettings.Current.PortalId, lang, hydrateLists, typeCode);
             }
-            return prdData;
+            return null;
         }
 
 	    public static ProductData GetProductData(String productId, String lang, Boolean hydrateLists = true)

--- a/Providers/PromoProvider/PromoProvider.cs
+++ b/Providers/PromoProvider/PromoProvider.cs
@@ -1,16 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Web.Hosting;
-using System.Web.UI.WebControls;
-using System.Xml;
-using DotNetNuke.Common.Utilities;
-using DotNetNuke.Entities.Portals;
-using NBrightCore.common;
+﻿using NBrightCore.common;
 using NBrightDNN;
 using Nevoweb.DNN.NBrightBuy.Components;
+using System;
+using System.Collections.Generic;
 
 namespace Nevoweb.DNN.NBrightBuy.Providers.PromoProvider
 {
@@ -20,9 +12,7 @@ namespace Nevoweb.DNN.NBrightBuy.Providers.PromoProvider
         {
             return PromoUtils.CalcGroupPromo(portalId);
         }
-
     }
-
 
     public class MultiBuyPromoScheudler : Components.Interfaces.SchedulerInterface
     {
@@ -30,7 +20,6 @@ namespace Nevoweb.DNN.NBrightBuy.Providers.PromoProvider
         {
             return PromoUtils.CalcMultiBuyPromo(portalId);
         }
-
     }
 
     public class CalcPromo : Components.Interfaces.PromoInterface
@@ -59,7 +48,7 @@ namespace Nevoweb.DNN.NBrightBuy.Providers.PromoProvider
                         var promoData = objCtrl.GetData(promoid);
                         if (promoData != null)
                         {
-                            //NOTE: WE nedd to process disabld promotions so they can be removed from cart
+                            //NOTE: WE need to process disabld promotions so they can be removed from cart
 
                             var buyqty = promoData.GetXmlPropertyInt("genxml/textbox/buyqty");
                             var validfrom = promoData.GetXmlProperty("genxml/textbox/validfrom");
@@ -69,8 +58,7 @@ namespace Nevoweb.DNN.NBrightBuy.Providers.PromoProvider
                             var amounttype = promoData.GetXmlProperty("genxml/radiobuttonlist/amounttype");
                             var amount = promoData.GetXmlPropertyDouble("genxml/textbox/amount");
 
-
-                                // Applied discount to this single cart item
+                            // Applied discount to this single cart item
                             if (!promoData.GetXmlPropertyBool("genxml/checkbox/disabled") && cartItemInfo.GetXmlPropertyInt("genxml/qty") >= buyqty && Utils.IsDate(validfrom) && Utils.IsDate(validuntil)) // check we have correct qty to activate promo
                             {
                                 var dteF = Convert.ToDateTime(validfrom).Date;
@@ -155,7 +143,7 @@ namespace Nevoweb.DNN.NBrightBuy.Providers.PromoProvider
             var promoid = nbrightInfo.GetXmlPropertyInt("genxml/hidden/promoid"); // legacy promo flag
             if (nbrightInfo.GetXmlPropertyBool("genxml/hidden/promoflag") || promoid > 0)
             {
-                var prdData = ProductUtils.GetProductData(nbrightInfo.ItemID, nbrightInfo.Lang);
+                var prdData = ProductUtils.GetProductData(nbrightInfo.ItemID, nbrightInfo.PortalId, nbrightInfo.Lang);
                 // loop on models to get all promoid at model level.
                 var modelpromoids = new List<int>();
                 if (promoid > 0) modelpromoids.Add(promoid);
@@ -183,7 +171,7 @@ namespace Nevoweb.DNN.NBrightBuy.Providers.PromoProvider
                     var propapplygroupid = promoData.GetXmlPropertyInt("genxml/dropdownlist/propapply");
 
                     var removepromo = true;
-                    foreach (var c in prdData.GetCategories())
+                    foreach (var c in prdData.GetCategories(nbrightInfo.PortalId))
                     {
                         if (c.categoryid == catgroupid) removepromo = false;
                         if (c.categoryid == propgroupid) removepromo = false;

--- a/Providers/PromoProvider/PromoUtils.cs
+++ b/Providers/PromoProvider/PromoUtils.cs
@@ -102,7 +102,7 @@ namespace Nevoweb.DNN.NBrightBuy.Providers.PromoProvider
                                 RemoveProductPromoData(p.PortalId, productid, p.ItemID);
                             }
                             ProductUtils.RemoveProductDataCache(p.PortalId, productid);
-                            var productData = ProductUtils.GetProductData(productid, lang);
+                            var productData = ProductUtils.GetProductData(productid, p.PortalId, lang);
                             productData.Save(); // recalc any new prices.
                         }
                         if (DateTime.Now.Date > dteU)
@@ -122,7 +122,7 @@ namespace Nevoweb.DNN.NBrightBuy.Providers.PromoProvider
                         // CALC Promo
                         CalcProductSalePrice(p.PortalId, productid, amounttype, amount, p.ItemID, whichprice, overwrite);
                         ProductUtils.RemoveProductDataCache(p.PortalId, productid);
-                        var productData = ProductUtils.GetProductData(productid, lang);
+                        var productData = ProductUtils.GetProductData(productid, p.PortalId, lang);
                         productData.Save(); // recalc any new prices.
                     }
                     p.SetXmlProperty("genxml/checkbox/disabled", "True");
@@ -136,7 +136,7 @@ namespace Nevoweb.DNN.NBrightBuy.Providers.PromoProvider
                         if (typeselect == "all") productid = prd.ItemID;
                         RemoveProductPromoData(p.PortalId, productid, p.ItemID);
                         ProductUtils.RemoveProductDataCache(p.PortalId, productid);
-                        var productData = ProductUtils.GetProductData(productid, lang);
+                        var productData = ProductUtils.GetProductData(productid, p.PortalId, lang);
                         productData.Save(); // recalc any new prices.
                     }
 
@@ -181,7 +181,7 @@ namespace Nevoweb.DNN.NBrightBuy.Providers.PromoProvider
                 // END Promo
                 RemoveProductPromoData(portalId, productid, p.ItemID);
                 ProductUtils.RemoveProductDataCache(prd.PortalId, productid);
-                var productData = ProductUtils.GetProductData(productid, lang);
+                var productData = ProductUtils.GetProductData(productid, portalId, lang);
                 productData.Save(); // recalc any new prices.
             }
             return "OK";
@@ -209,7 +209,7 @@ namespace Nevoweb.DNN.NBrightBuy.Providers.PromoProvider
                     }
                     objCtrl.Update(prdData);
                     RemoveProductPromoData(portalId, productId, promoid);
-                    var productData = ProductUtils.GetProductData(productId, lang);
+                    var productData = ProductUtils.GetProductData(productId, portalId, lang);
                     productData.Save(); // recalc any new prices.
                 }
             }
@@ -419,7 +419,7 @@ namespace Nevoweb.DNN.NBrightBuy.Providers.PromoProvider
                             objCtrl.Update(p);
                         }
                         ProductUtils.RemoveProductDataCache(p.PortalId, prd.ParentItemId);
-                        var productData = ProductUtils.GetProductData(prd.ParentItemId, lang);
+                        var productData = ProductUtils.GetProductData(prd.ParentItemId, p.PortalId, lang);
                         productData.Save(); // recalc any new prices.
                     }
 
@@ -492,7 +492,7 @@ namespace Nevoweb.DNN.NBrightBuy.Providers.PromoProvider
                     // END Promo
                     RemoveProductPromoData(portalId, prd.ParentItemId, promoid);
                     ProductUtils.RemoveProductDataCache(prd.PortalId, prd.ParentItemId);
-                    var productData = ProductUtils.GetProductData(prd.ParentItemId, lang);
+                    var productData = ProductUtils.GetProductData(prd.ParentItemId, portalId, lang);
                     productData.Save(); // recalc any new prices.
                 }
             }
@@ -509,7 +509,7 @@ namespace Nevoweb.DNN.NBrightBuy.Providers.PromoProvider
                         // END Promo
                         RemoveProductPromoData(p.PortalId, prd.ParentItemId, p.ItemID);
                         ProductUtils.RemoveProductDataCache(p.PortalId, prd.ParentItemId);
-                        var productData = ProductUtils.GetProductData(prd.ParentItemId, lang);
+                        var productData = ProductUtils.GetProductData(prd.ParentItemId, p.PortalId, lang);
                         productData.Save(); // recalc any new prices.
                     }
                 }


### PR DESCRIPTION
Changes to ensure the scheduler executes the MultiBuyPromoScheduler successfully for promotion pricing calculations.

Couple things worth noting.

I removing the unused usings from the PromoProvider.  We can re-introduce if it'll cause problems but I don't think it should. 

The GroupCatController change was also something that is not directly related to the portal id issue but I bumped into it en-route to testing that issue.  I received a null error which I added a defensive check to prevent.

All other changes are intended to ensure the portal id is available when GroupPromoScheduler DoWork func gets called by the scheduler.

Possible fix for the issue in discussion #185