### PR TITLE
Fix default product list sorting. 

### DIFF
--- a/Themes/Bootstrap4/Default/ProductDisplayAjax.cshtml
+++ b/Themes/Bootstrap4/Default/ProductDisplayAjax.cshtml
@@ -6,6 +6,7 @@
 @using Nevoweb.DNN.NBrightBuy.Components;
 
 @AddMetaData("resourcepath", "/DesktopModules/NBright/NBrightBuy/App_LocalResources/")
+@* //note: You must include 1 AddPreProcessMetaData token here(or leave this comment) to ensure ProductDisplayAjaxList template pre processor meta data tokens get parsed *@
 
 <script>
     $(document).ready(function () {
@@ -13,7 +14,7 @@
         $('#moduleid').val('@Model.ModuleId');
         $('#pagesize').val('@Model.GetSetting("pagesize", "0")');
         $('#themefolder').val('@Model.GetSetting("themefolder")');
-        $('#entitytypecode').val('@Model.GetSetting("entitytypecode")');        
+        $('#entitytypecode').val('@Model.GetSetting("entitytypecode")');
         $("#modkey").val("@Model.ModuleRef");
         //loadProductList("@Model.ModuleId");
     });

--- a/Themes/ClassicAjax/Default/ProductDisplayAjax.cshtml
+++ b/Themes/ClassicAjax/Default/ProductDisplayAjax.cshtml
@@ -6,6 +6,7 @@
 @using Nevoweb.DNN.NBrightBuy.Components;
 
 @AddMetaData("resourcepath", "/DesktopModules/NBright/NBrightBuy/App_LocalResources/")
+@* //note: You must include 1 AddPreProcessMetaData token here(or leave this comment) to ensure ProductDisplayAjaxList template pre processor meta data tokens get parsed *@
 
 <script>
     $(document).ready(function () {
@@ -13,7 +14,7 @@
         $('#moduleid').val('@Model.ModuleId');
         $('#pagesize').val('@Model.GetSetting("pagesize", "0")');
         $('#themefolder').val('@Model.GetSetting("themefolder")');
-        $('#entitytypecode').val('@Model.GetSetting("entitytypecode")');        
+        $('#entitytypecode').val('@Model.GetSetting("entitytypecode")');
         $("#modkey").val("@Model.ModuleRef");
         //loadProductList("@Model.ModuleId");
     });


### PR DESCRIPTION
The first render template needs to have the AddPreProcessMetaData keyword in the source to ensure the full template gets parsed for meta data tokens.  