### PR TITLE
Ensures data from an eventprovider is used

### DIFF
--- a/Components/Orders/OrderData.cs
+++ b/Components/Orders/OrderData.cs
@@ -93,8 +93,7 @@ namespace Nevoweb.DNN.NBrightBuy.Components
 
                 SavePurchaseData();
 
-                NBrightBuyUtils.ProcessEventProvider(EventActions.AfterOrderStatusChange, PurchaseInfo);
-
+                PurchaseInfo = NBrightBuyUtils.ProcessEventProvider(EventActions.AfterOrderStatusChange, PurchaseInfo);
             }  
         }
 


### PR DESCRIPTION
An eventprovider might change the order data, if it does it will return that data. With this change OS actually uses that in stead of overwrites it with the old data again.

Closes #216