### PR TITLE
Feature/sortable product properties

### DIFF
--- a/App_LocalResources/General.ascx.nl-NL.resx
+++ b/App_LocalResources/General.ascx.nl-NL.resx
@@ -1095,135 +1095,135 @@
   <data name="DealerOnly.Text" xml:space="preserve">
     <value>Alleen dealer</value>
   </data>
-	<data name="seooptimization.Text" xml:space="preserve">
-		<value>SEO (optioneel)</value>
-	</data>
-	<data name="seonamehelp.Text" xml:space="preserve">
-		<value>Alternatieve naam voor het produkt, voor gebruik in de URL.</value>
-	</data>
-	<data name="seotitlehelp.Text" xml:space="preserve">
-		<value>Alternatieve META Title (produktnaam is standaard)</value>
-	</data>
-	<data name="seodescriptionhelp.Text" xml:space="preserve">
-		<value>Alternatieve Meta Description (samenvatting is standaard)</value>
-	</data>
-	<data name="allowupload.Text" xml:space="preserve">
-		<value>Uploads van klanten toestaan</value>
-	</data>
-	<data name="ReturnTo.Text" xml:space="preserve">
-		<value>Terug naar</value>
-	</data>
-	<data name="Manufacturer.Text" xml:space="preserve">
-		<value>Fabrikant</value>
-	</data>
-	<data name="DealerSale.Text" xml:space="preserve">
-		<value>Dealer aanbieding</value>
-	</data>
-	<data name="disablesale.Text" xml:space="preserve">
-		<value>geen sale</value>
-	</data>
-	<data name="disabledealer.Text" xml:space="preserve">
-		<value>geen dealer</value>
-	</data>
-	<data name="searchfilter.Text" xml:space="preserve">
-		<value>Zoekfilter weergeven</value>
-	</data>
-	<data name="fea.Text" xml:space="preserve">
-		<value>Features</value>
-	</data>
-	<data name="promo.Text" xml:space="preserve">
-		<value>Promoties</value>
-	</data>
-	<data name="spec.Text" xml:space="preserve">
-		<value>Specificaties</value>
-	</data>
-	<data name="supp.Text" xml:space="preserve">
-		<value>Leverancier</value>
-	</data>
-	<data name="temp.Text" xml:space="preserve">
-		<value>Tijdelijk</value>
-	</data>
-	<data name="cat.Text" xml:space="preserve">
-		<value>Categoriën</value>
-	</data>
-	<data name="man.Text" xml:space="preserve">
-		<value>Fabrikant</value>
-	</data>
-	<data name="QtyUnits.Text" xml:space="preserve">
-		<value>Aantal eenh.</value>
-	</data>
-	<data name="txtemptybasket.Text" xml:space="preserve">
-		<value>Uw winkelwagen is leeg</value>
-	</data>
-	<data name="txtitems.Text" xml:space="preserve">
-		<value>Subtotaal</value>
-	</data>
-	<data name="pleaseselect.Text" xml:space="preserve">
-		<value>Maak een keuze</value>
-	</data>
-	<data name="ApplyTax.Text" xml:space="preserve">
-		<value>BTW percentage toepassen op alle artikelen in categorie</value>
-	</data>
-	<data name="GroupType.Text" xml:space="preserve">
-		<value>Soort groep</value>
-	</data>
-	<data name="filtergroups.Text" xml:space="preserve">
-		<value>Filtergroepen</value>
-	</data>
-	<data name="group.Text" xml:space="preserve">
-		<value>Groep</value>
-	</data>
-	<data name="filter.Text" xml:space="preserve">
-		<value>Filter</value>
-	</data>
-	<data name="createnewlist.Text" xml:space="preserve">
-		<value>Maak nieuwe lijst</value>
-	</data>
-	<data name="listtitle.Text" xml:space="preserve">
-		<value>Kies een lijst</value>
-	</data>
-	<data name="shoppinglistadd.Text" xml:space="preserve">
-		<value>Aan deze lijst toevoegen</value>
-	</data>
-	<data name="createlist.Text" xml:space="preserve">
-		<value>Maak lijst</value>
-	</data>
-	<data name="cancellist.Text" xml:space="preserve">
-		<value>Annuleren</value>
-	</data>
-	<data name="IgnoreShared.Text" xml:space="preserve">
-		<value>Gedeelde records negeren</value>
-	</data>
-	<data name="login.Text" xml:space="preserve">
-		<value>Inloggen</value>
-	</data>
-	<data name="loginpopupmsg.Text" xml:space="preserve">
-		<value>Log in om artikelen aan uw favorieten toe te voegen.</value>
-	</data>
-	<data name="AccessToClient.Text" xml:space="preserve">
-		<value>Toegang verleend aan klant</value>
-	</data>
-	<data name="cmdResetButton.confirm" xml:space="preserve">
-		<value>Reset record?</value>
-	</data>
-	<data name="included.Text" xml:space="preserve">
-		<value>(incl.)</value>
-	</data>
-	<data name="AddressName.Text" xml:space="preserve">
-		<value>Adres naam</value>
-	</data>
-	<data name="cascade.Text" xml:space="preserve">
-		<value>Cascade</value>
-	</data>
-	<data name="enabled.Text" xml:space="preserve">
-		<value>Ingeschakeld</value>
-	</data>
-	<data name="visible.Text" xml:space="preserve">
-		<value>Zichtbaar</value>
-	</data>
-	<data name="owner.Text" xml:space="preserve">
-		<value>Eigenaar</value>
-	</data>
+  <data name="seooptimization.Text" xml:space="preserve">
+    <value>SEO (optioneel)</value>
+  </data>
+  <data name="seonamehelp.Text" xml:space="preserve">
+    <value>Alternatieve naam voor het produkt, voor gebruik in de URL.</value>
+  </data>
+  <data name="seotitlehelp.Text" xml:space="preserve">
+    <value>Alternatieve META Title (produktnaam is standaard)</value>
+  </data>
+  <data name="seodescriptionhelp.Text" xml:space="preserve">
+    <value>Alternatieve Meta Description (samenvatting is standaard)</value>
+  </data>
+  <data name="allowupload.Text" xml:space="preserve">
+    <value>Uploads van klanten toestaan</value>
+  </data>
+  <data name="ReturnTo.Text" xml:space="preserve">
+    <value>Terug naar</value>
+  </data>
+  <data name="Manufacturer.Text" xml:space="preserve">
+    <value>Fabrikant</value>
+  </data>
+  <data name="DealerSale.Text" xml:space="preserve">
+    <value>Dealer aanbieding</value>
+  </data>
+  <data name="disablesale.Text" xml:space="preserve">
+    <value>geen sale</value>
+  </data>
+  <data name="disabledealer.Text" xml:space="preserve">
+    <value>geen dealer</value>
+  </data>
+  <data name="searchfilter.Text" xml:space="preserve">
+    <value>Zoekfilter weergeven</value>
+  </data>
+  <data name="fea.Text" xml:space="preserve">
+    <value>Features</value>
+  </data>
+  <data name="promo.Text" xml:space="preserve">
+    <value>Promoties</value>
+  </data>
+  <data name="spec.Text" xml:space="preserve">
+    <value>Specificaties</value>
+  </data>
+  <data name="supp.Text" xml:space="preserve">
+    <value>Leverancier</value>
+  </data>
+  <data name="temp.Text" xml:space="preserve">
+    <value>Tijdelijk</value>
+  </data>
+  <data name="cat.Text" xml:space="preserve">
+    <value>Categoriën</value>
+  </data>
+  <data name="man.Text" xml:space="preserve">
+    <value>Fabrikant</value>
+  </data>
+  <data name="QtyUnits.Text" xml:space="preserve">
+    <value>Aantal eenh.</value>
+  </data>
+  <data name="txtemptybasket.Text" xml:space="preserve">
+    <value>Uw winkelwagen is leeg</value>
+  </data>
+  <data name="txtitems.Text" xml:space="preserve">
+    <value>Subtotaal</value>
+  </data>
+  <data name="pleaseselect.Text" xml:space="preserve">
+    <value>Maak een keuze</value>
+  </data>
+  <data name="ApplyTax.Text" xml:space="preserve">
+    <value>BTW percentage toepassen op alle artikelen in categorie</value>
+  </data>
+  <data name="GroupType.Text" xml:space="preserve">
+    <value>Soort groep</value>
+  </data>
+  <data name="filtergroups.Text" xml:space="preserve">
+    <value>Filtergroepen</value>
+  </data>
+  <data name="group.Text" xml:space="preserve">
+    <value>Groep</value>
+  </data>
+  <data name="filter.Text" xml:space="preserve">
+    <value>Filter</value>
+  </data>
+  <data name="createnewlist.Text" xml:space="preserve">
+    <value>Maak nieuwe lijst</value>
+  </data>
+  <data name="listtitle.Text" xml:space="preserve">
+    <value>Kies een lijst</value>
+  </data>
+  <data name="shoppinglistadd.Text" xml:space="preserve">
+    <value>Aan deze lijst toevoegen</value>
+  </data>
+  <data name="createlist.Text" xml:space="preserve">
+    <value>Maak lijst</value>
+  </data>
+  <data name="cancellist.Text" xml:space="preserve">
+    <value>Annuleren</value>
+  </data>
+  <data name="IgnoreShared.Text" xml:space="preserve">
+    <value>Gedeelde records negeren</value>
+  </data>
+  <data name="login.Text" xml:space="preserve">
+    <value>Inloggen</value>
+  </data>
+  <data name="loginpopupmsg.Text" xml:space="preserve">
+    <value>Log in om artikelen aan uw favorieten toe te voegen.</value>
+  </data>
+  <data name="AccessToClient.Text" xml:space="preserve">
+    <value>Toegang verleend aan klant</value>
+  </data>
+  <data name="cmdResetButton.confirm" xml:space="preserve">
+    <value>Reset record?</value>
+  </data>
+  <data name="included.Text" xml:space="preserve">
+    <value>(incl.)</value>
+  </data>
+  <data name="AddressName.Text" xml:space="preserve">
+    <value>Adres naam</value>
+  </data>
+  <data name="cascade.Text" xml:space="preserve">
+    <value>Cascade</value>
+  </data>
+  <data name="enabled.Text" xml:space="preserve">
+    <value>Ingeschakeld</value>
+  </data>
+  <data name="visible.Text" xml:space="preserve">
+    <value>Zichtbaar</value>
+  </data>
+  <data name="owner.Text" xml:space="preserve">
+    <value>Eigenaar</value>
+  </data>
   <data name="RefValidationMessage.Text" xml:space="preserve">
     <value>Ref mag alleen in kleine letters alfanumeriek zijn zonder lege spaties.</value>
   </data>
@@ -1247,5 +1247,11 @@
   </data>
   <data name="QtyMinPurchase.Text" xml:space="preserve">
     <value>Minimale afnamehoeveelheid</value>
+  </data>
+  <data name="cmdMoveDownIcon.Text" xml:space="preserve">
+    <value>&lt;i title="Omlaag" class="fa fa-arrow-circle-down  fa-fw fa-2x"&gt;&lt;/i&gt;</value>
+  </data>
+  <data name="cmdMoveUpIcon.Text" xml:space="preserve">
+    <value>&lt;i title="Omhoog" class="fa fa-arrow-circle-up  fa-fw fa-2x"&gt;&lt;/i&gt;</value>
   </data>
 </root>

--- a/App_LocalResources/General.ascx.resx
+++ b/App_LocalResources/General.ascx.resx
@@ -1260,4 +1260,10 @@
   <data name="QtyMinPurchase.Text" xml:space="preserve">
     <value>Minimum Purchase Qty</value>
   </data>
+  <data name="cmdMoveDownIcon.Text" xml:space="preserve">
+    <value>&lt;i title="Down" class="fa fa-arrow-circle-down  fa-fw fa-2x"&gt;&lt;/i&gt;</value>
+  </data>
+  <data name="cmdMoveUpIcon.Text" xml:space="preserve">
+    <value>&lt;i title="Up" class="fa fa-arrow-circle-up  fa-fw fa-2x"&gt;&lt;/i&gt;</value>
+  </data>
 </root>

--- a/Components/Product/ProductData.cs
+++ b/Components/Product/ProductData.cs
@@ -448,12 +448,12 @@ namespace Nevoweb.DNN.NBrightBuy.Components
         /// <param name="groupref">groupref for select, "" = all, "cat"= Category only, "!cat" = all non-category, "{groupref}"=this group only</param>
         /// <param name="cascade">get all cascade records to get all parent categories</param>
         /// <returns></returns>
-        public List<GroupCategoryData> GetCategories(int portalId, String groupref = "", Boolean cascade = false)
+        public List<GroupCategoryData> GetCategories(int portalId, String groupref = "", bool cascade = false, bool useSort = false)
         {
             if (Info == null) return new List<GroupCategoryData>(); // stop throwing an error no product exists,
 
             var objGrpCtrl = new GrpCatController(_lang, portalId);
-            var catl = objGrpCtrl.GetProductCategories(Info.ItemID, groupref, cascade);
+            var catl = objGrpCtrl.GetProductCategories(Info.ItemID, groupref, cascade, useSort);
             if (Utils.IsNumeric(DataRecord.GetXmlProperty("genxml/defaultcatid")) && catl.Count > 0)
             {
                 var objl = catl.Where(i => i.isdefault == true);
@@ -476,10 +476,10 @@ namespace Nevoweb.DNN.NBrightBuy.Components
         /// <param name="groupref">groupref for select, "" = all, "cat"= Category only, "!cat" = all non-category, "{groupref}"=this group only</param>
         /// <param name="cascade">get all cascade records to get all parent categories</param>
         /// <returns></returns>
-        public List<GroupCategoryData> GetCategories(String groupref = "", Boolean cascade = false)
+        public List<GroupCategoryData> GetCategories(String groupref = "", bool cascade = false, bool useSort = false)
         {
             var portalId = PortalSettings.Current.PortalId;
-            return GetCategories(portalId, groupref, cascade);
+            return GetCategories(portalId, groupref, cascade, useSort);
         }
 
         /// <summary>
@@ -488,9 +488,14 @@ namespace Nevoweb.DNN.NBrightBuy.Components
         /// <param name="groupref">groupref for select, "" = all, "cat"= Category only, "!cat" = all non-category, "{groupref}"=this group only</param>
         /// <param name="cascade">get all cascade records to get all parent categories</param>
         /// <returns></returns>
-        public List<GroupCategoryData> GetProperties(String groupref = "!cat", Boolean cascade = false)
+        public List<GroupCategoryData> GetProperties(String groupref = "!cat", bool cascade = false)
         {
-            return GetCategories(groupref, cascade);
+            return GetCategories(groupref, cascade, true);
+        }
+        public void MoveProperty(int categoryid, int change)
+        {
+            var objGrpCtrl = new GrpCatController(_lang);
+            objGrpCtrl.MoveProductCategory(Info.ItemID, categoryid, change);
         }
 
         public GroupCategoryData GetDefaultCategory()

--- a/Components/Product/ProductFunctions.cs
+++ b/Components/Product/ProductFunctions.cs
@@ -125,6 +125,12 @@ namespace Nevoweb.DNN.NBrightBuy.Components.Products
                     case "product_admin_removeproperty":
                         strOut = RemoveProperty(context);
                         break;
+                    case "product_admin_moveupproperty":
+                        strOut = MoveProperty(context, -1);
+                        break;
+                    case "product_admin_movednproperty":
+                        strOut = MoveProperty(context, 1);
+                        break;
                     case "product_admin_removerelated":
                         strOut = RemoveRelatedProduct(context);
                         break;
@@ -1442,6 +1448,28 @@ namespace Nevoweb.DNN.NBrightBuy.Components.Products
                     prodData.RemoveCategory(Convert.ToInt32(xrefitemid));
                     ProductUtils.RemoveProductDataCache(PortalSettings.Current.PortalId, parentitemid);
                     NBrightBuyUtils.RemoveModCachePortalWide(prodData.Info.PortalId);
+                    return GetProperties(context);
+                }
+                return "Invalid parentitemid or xrefitmeid";
+            }
+            catch (Exception e)
+            {
+                return e.ToString();
+            }
+        }
+
+        public string MoveProperty(HttpContext context, int change)
+        {
+            try
+            {
+                var ajaxInfo = NBrightBuyUtils.GetAjaxInfo(context);
+                var parentitemid = ajaxInfo.GetXmlPropertyInt("genxml/hidden/selecteditemid");
+                var xrefitemid = ajaxInfo.GetXmlPropertyInt("genxml/hidden/selectedcatid");
+                if (xrefitemid > 0 && parentitemid > 0)
+                {
+                    var prodData = ProductUtils.GetProductData(parentitemid, EditLangCurrent, false);
+                    prodData.MoveProperty(Convert.ToInt32(xrefitemid), change);
+                    ProductUtils.RemoveProductDataCache(PortalSettings.Current.PortalId, parentitemid);
                     return GetProperties(context);
                 }
                 return "Invalid parentitemid or xrefitmeid";

--- a/Themes/config/css/backoffice.css
+++ b/Themes/config/css/backoffice.css
@@ -224,7 +224,10 @@ a.sortelementLeft, a.sortelementRight {
 .editproperties .selectgrouptype{height:110px}
 .editproperties .selectgroupcategory{height:200px;margin-top:15px}
 .editproperties .removecategory.btn{margin-bottom:0}
-.editrelated{}
+.editproperties a.movedngroupcategory, .editproperties a.moveupgroupcategory{ cursor: pointer;}
+.editproperties a.movedngroupcategory:hover, .editproperties a.moveupgroupcategory:hover { color: #47BE27 }
+
+.editrelated {}
 .editrelated .productrelated{list-style: none outside none;margin: 0;padding: 0;}
 .editrelated .productrelated > li{float:left}
 .editrelated .relatedlistitem{list-style: none outside none;margin: 0 6px 6px 0;padding: 0;background:#FFFFFF;width:120px;height:160px;position: relative;border:1px dotted #E3E3E3}

--- a/Themes/config/default/Admin_ProductProperties.cshtml
+++ b/Themes/config/default/Admin_ProductProperties.cshtml
@@ -9,14 +9,30 @@
 @{
     var info = (NBrightInfo)Model.List.First();
     var prdData = new ProductData(info.ItemID, info.PortalId, info.Lang);
+    var prdProps = prdData.GetProperties();
 }
 
-@foreach (var nbiCat in prdData.GetProperties())
+@foreach (var nbiCat in prdProps)
 {
     <tr>
         <td style="white-space:nowrap" title="Reference code: @nbiCat.grouptyperef">@nbiCat.groupname</td>
         <td title="Breadcrumb: @nbiCat.breadcrumb">@nbiCat.categoryname</td>
-        <td><a class="removegroupcategory" itemid="@info.ItemID" categoryid="@nbiCat.categoryid">@ResourceKey("General.cmdRemoveIcon")</a><span class="hidden">@nbiCat.categoryid</span></td>
+        <td>
+            <a class="removegroupcategory" itemid="@info.ItemID" categoryid="@nbiCat.categoryid">@ResourceKey("General.cmdRemoveIcon")</a><span class="hidden">@nbiCat.categoryid</span>
+        </td>
+        <td>
+            @if (prdProps.IndexOf(nbiCat) < prdProps.Count - 1)
+            {
+                <a class="movedngroupcategory" itemid="@info.ItemID" categoryid="@nbiCat.categoryid">@ResourceKey("General.cmdMoveDownIcon")</a><span class="hidden">@nbiCat.categoryid</span>
+            }
+        </td>
+        <td>
+            @if (prdProps.IndexOf(nbiCat) > 0)
+            {
+                <a class="moveupgroupcategory" itemid="@info.ItemID" categoryid="@nbiCat.categoryid">@ResourceKey("General.cmdMoveUpIcon")</a>
+                <span class="hidden">@nbiCat.categoryid</span>
+            }
+        </td>
     </tr>
 }
 

--- a/Themes/config/js/admin_product.js
+++ b/Themes/config/js/admin_product.js
@@ -325,7 +325,7 @@ function Admin_product_nbxgetCompleted(e) {
         initImgDisplay();
     }
 
-    if (e.cmd == 'product_admin_populatecategorylist' || e.cmd == 'product_admin_addproperty' || e.cmd == 'product_admin_removeproperty') {
+    if (e.cmd == 'product_admin_populatecategorylist' || e.cmd == 'product_admin_addproperty' || e.cmd == 'product_admin_removeproperty' || e.cmd == 'product_admin_moveupproperty' || e.cmd == 'product_admin_movednproperty') {
         initPropertyDisplay();
     }
     if (e.cmd == 'product_admin_addproductcategory' || e.cmd == 'product_admin_removeproductcategory' || e.cmd == 'product_admin_setdefaultcategory') {
@@ -650,6 +650,22 @@ function initDocDisplay() {
             $('#p1_selectedcatid').val($(this).attr('categoryid'));
             $('#p1_razortemplate').val("Admin_ProductProperties.cshtml");
             nbxget('product_admin_removeproperty', '#selectparams_Product_Admin', '#productgroupcategories'); // load             
+        });
+
+        $('.moveupgroupcategory').unbind('click');
+        $('.moveupgroupcategory').click(function () {
+            $('.processing').show();
+            $('#p1_selectedcatid').val($(this).attr('categoryid'));
+            $('#p1_razortemplate').val("Admin_ProductProperties.cshtml");
+            nbxget('product_admin_moveupproperty', '#selectparams_Product_Admin', '#productgroupcategories'); // load             
+        });
+
+        $('.movedngroupcategory').unbind('click');
+        $('.movedngroupcategory').click(function () {
+            $('.processing').show();
+            $('#p1_selectedcatid').val($(this).attr('categoryid'));
+            $('#p1_razortemplate').val("Admin_ProductProperties.cshtml");
+            nbxget('product_admin_movednproperty', '#selectparams_Product_Admin', '#productgroupcategories'); // load             
         });
 
         $('.selectproperty').unbind('click');


### PR DESCRIPTION
This PR introduces the option to sort product properties on product level by adding up and down buttons like this:
![image](https://user-images.githubusercontent.com/4275042/169245976-932cd26b-dc14-4af4-a7d7-adbfd4c890c1.png)

This uses the genxml/sort field of the CATXREF record that was already filled but not used.
Since the ProductData.GetProperties method now sorts by genxml/sort, we don't need to change the templates.

There is a chance that current order of properties will change with this update. But since the user or admin did not have influence on that, my guess is that should not be a problem.